### PR TITLE
Update to PETSIRD v0.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir -p /home/vscode/.local/share/CMakeTools \
     && chown vscode:conda /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json
 
 # Install the yardl tool
-ARG YARDL_VERSION=0.6.2
+ARG YARDL_VERSION=0.6.3
 RUN wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && mv yardl "/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin/" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           mkdir ${YARDL_DIR}
           cd ${YARDL_DIR}
           echo "${{github.workspace}}/yardl" >> $GITHUB_PATH
-          YARDL_VERSION=0.3.2
+          YARDL_VERSION=0.6.3
           wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
           tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
           rm "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,12 +19,13 @@ endif()
 set(PETSIRD_dir ../PETSIRD/cpp/generated)
 add_subdirectory(${PETSIRD_dir} PETSIRD_generated)
 
-find_package(ROOT REQUIRED COMPONENTS Core Imt RIO Net Hist Graf Graf3d Gpad Tree TreePlayer Rint Postscript Matrix Physics MathCore Thread MultiProc ROOTDataFrame)
+find_package(ROOT REQUIRED COMPONENTS Tree)
+
 add_executable(root_to_petsird main.cpp)
 target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir})
 # needed for helpers
 target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir}/..)
 target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir}/../helpers/include)
 target_link_libraries(root_to_petsird PUBLIC petsird_generated)
-target_link_libraries(root_to_petsird PUBLIC ROOT::Core ROOT::Imt ROOT::RIO ROOT::Net ROOT::Hist ROOT::Graf ROOT::Graf3d ROOT::Gpad ROOT::Tree ROOT::TreePlayer ROOT::Rint ROOT::Postscript ROOT::Matrix ROOT::Physics ROOT::MathCore ROOT::Thread ROOT::MultiProc ROOT::ROOTDataFrame)
+target_link_libraries(root_to_petsird PUBLIC ROOT::Tree)
 install(TARGETS root_to_petsird DESTINATION bin)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12.0) # older would work, but could give warnings on policy CMP0074
-project(root_to_petsird VERSION 0.2.0)
+project(root_to_petsird VERSION 0.3.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -24,6 +24,7 @@ add_executable(root_to_petsird main.cpp)
 target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir})
 # needed for helpers
 target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir}/..)
+target_include_directories(root_to_petsird PUBLIC ${PETSIRD_dir}/../helpers/include)
 target_link_libraries(root_to_petsird PUBLIC petsird_generated)
 target_link_libraries(root_to_petsird PUBLIC ROOT::Core ROOT::Imt ROOT::RIO ROOT::Net ROOT::Hist ROOT::Graf ROOT::Graf3d ROOT::Gpad ROOT::Tree ROOT::TreePlayer ROOT::Rint ROOT::Postscript ROOT::Matrix ROOT::Physics ROOT::MathCore ROOT::Thread ROOT::MultiProc ROOT::ROOTDataFrame)
 install(TARGETS root_to_petsird DESTINATION bin)

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -263,8 +263,8 @@ int calculate_element_index(int module_id, int submodule_id, int crystal_id, con
   int N_CRY_z = scannerGeometry.n_cry_z;
   // int N_CRY_layers = scannerGeometry.n_cry_layers;
 
-  return (Int_t)((module_id*N_SMOD_xy*N_SMOD_z)
-                 + submodule_id*N_CRY_xy*N_CRY_z
+  return (Int_t)(((module_id*N_SMOD_xy*N_SMOD_z)
+                  + submodule_id)*N_CRY_xy*N_CRY_z
                  + crystal_id);
 }
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -7,58 +7,25 @@
 //  * regarding  this  software system or assume any liability for its  *
 //  * use.                                                              *
 //  *                                                                   *
-//  * This  code  implementation is the  intellectual property  of the  *
-//  * OpenGATE collaboration.                                           *
 //  * By copying,  distributing  or modifying the Program (or any work  *
 //  * based  on  the Program)  you indicate  your  acceptance of  this  *
 //  * statement, and all its terms.                                     *
 //  *********************************************************************
 //
 //######################################################################################
-//# Authors   : Nicolas A Karakatsanis,                                                #
+//# Authors   : Nicolas A Karakatsanis, Kris Thielemans                                #
 //#                                                                                    #
-//# Date  03-NOV-2024                                                                  #
+//# Date  03-NOV-2024 - July 2025                                                      #
 //#                                                                                    #
-//# Objective : To read the coincidences TTree from the .root file, and generates the  #
-//#             corresponding Michelogram and Projection files.                        #
+//# Objective : To read the coincidences TTree from the .root file, and generate  the  #
+//#             corresponding PETSIRD file.                                            #
 //#                                                                                    #
 //# Input     : Monte Carlo data from GATE                                             #
 //#                                                                                    #
-//# Output    : 1 Michelogram  files according to various binning definitions          #
-//#           : 2 Projection  files according to various binning definitions           #
+//# Output    : PETSIRD file (tested with v0.7)                                        #
 //#                                                                                    #
 //######################################################################################
 //#                                                                                    #
-//# This file is last modified on Nov 03, 2024 by: N. Karakatsanis                     #
-//#                                                                                    #
-//# The data are input from a root file produced by Gate simulating extended FOV of    #
-//# mCT scanner. This scanner will have 5xFOV thus the root file contains information  #
-//# on every gantry. In this case there are 5 gantries with gantryID (0 -> 4).         #
-//# The ring numbers are defined based on the gantryID.                                #
-//#                                                                                    #
-//# The virtual rings between the blocks are taken into consideration here.            #
-//#                                                                                    #
-//# The central FOV is taken into consideration                                        #
-//# The maximum and minimum rings should be specified if the user wishes to change     #
-//# the number or the order of gantries.                                               #
-//#                                                                                    #
-//#                                                                                    #
-//#                                                                                    #
-//#                                                                                    #
-//#  NEW WAY TO RUN:                                                                   #
-//#                                                                                    #
-//# HOW TO COMPILE:                                                                    #
-//# 1) Compile using this command line in the terminal:                                #
-//#       g++ (name of file) `root-config --cflags --libs`                             #
-//#                                                                                    #
-//# HOW TO RUN:                                                                        #
-//# 1) After compiling the code type the following command line:                       #
-//#       ./a.out 'directory name of root files' 'output file name' 'yes/no'           #
-//#                                                                                    #
-//# NOTE: 1) To drop the odd ring put 'yes' as an argument when running, otherwise the #
-//# rings will not be droped.                                                          #
-//#       2) You will be prompted to enter the minimum ring number                     #
-//######################################################################################
 
 
 

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -301,12 +301,12 @@ get_detector_module(ScannerGeometry& scannerGeometry)
   petsird::ReplicatedBoxSolidVolume rep_volume;
   {
     rep_volume.object = get_crystal(scannerGeometry);
-    for (int rep_mod_xy = 0; rep_mod_xy < scannerGeometry.n_mod_xy; ++rep_mod_xy)
-        for (int rep_mod_z = 0; rep_mod_z < scannerGeometry.n_mod_z; ++rep_mod_z)
+    for (int rep_mod_z = 0; rep_mod_z < scannerGeometry.n_mod_z; ++rep_mod_z)
+      for (int rep_mod_xy = 0; rep_mod_xy < scannerGeometry.n_mod_xy; ++rep_mod_xy)
+        for (int rep_smod_z = 0; rep_smod_z < scannerGeometry.n_smod_z; ++rep_smod_z)
           for (int rep_smod_xy = 0; rep_smod_xy < scannerGeometry.n_smod_xy; ++rep_smod_xy)
-            for (int rep_smod_z = 0; rep_smod_z < scannerGeometry.n_smod_z; ++rep_smod_z)
+            for (int rep_cry_z = 0; rep_cry_z < scannerGeometry.n_cry_z; ++rep_cry_z)
               for (int rep_cry_xy = 0; rep_cry_xy < scannerGeometry.n_cry_xy; ++rep_cry_xy)
-                for (int rep_cry_z = 0; rep_cry_z < scannerGeometry.n_cry_z; ++rep_cry_z)
                   for (int rep_cry_layer = 0; rep_cry_layer < scannerGeometry.n_cry_layers; ++rep_cry_layer)
                     {
                       petsird::RigidTransformation transform{ { { 1.0, 0.0, 0.0, scannerGeometry.radius + rep_cry_layer * scannerGeometry.detector_x_dim },
@@ -665,7 +665,7 @@ int main(int argc, char** argv)
         expanded_detection_bin.energy_index = static_cast<uint32_t>(energyToIdx(1.0e3*energy1, scanner));
         event.detection_bins[0] = petsird_helpers::make_detection_bin(header.scanner, type_of_module, expanded_detection_bin);
         expanded_detection_bin.module_index = calculate_module_index(gantryID2, rsectorID2, scannerGeometry);
-        expanded_detection_bin.element_index = calculate_element_index(moduleID1, submoduleID1, crystalID1, scannerGeometry);
+        expanded_detection_bin.element_index = calculate_element_index(moduleID2, submoduleID2, crystalID2, scannerGeometry);
         expanded_detection_bin.energy_index = static_cast<uint32_t>(energyToIdx(1.0e3*energy2, scanner));
         event.detection_bins[1] = petsird_helpers::make_detection_bin(header.scanner, type_of_module, expanded_detection_bin);
         double dt_psec = 1.0e12f*(time1 - time2); //in psec
@@ -688,6 +688,10 @@ int main(int argc, char** argv)
                     << "el=" << expanded_detection_bin1.element_index << ", "
                     << "energy_index=" << expanded_detection_bin1.energy_index << ")]\n";
           std::cout << "  tof_idx: " << event.tof_idx << std::endl;
+          std::cout << "gantryID1=" << gantryID1 << ", rsectorID1=" << rsectorID1
+                    << ", moduleID1=" << moduleID1 << ", submoduleID1=" << submoduleID1 << ", crystalID1=" << crystalID1 << '\n';
+          std::cout << "gantryID2=" << gantryID2 << ", rsectorID2=" << rsectorID2
+                    << ", moduleID2=" << moduleID2 << ", submoduleID2=" << submoduleID2 << ", crystalID2=" << crystalID2 << '\n';
           const auto box_shape0 = petsird_helpers::geometry::get_detecting_box(header.scanner, type_of_module, expanded_detection_bin0);
           const auto mean_pos0 = mean_position(box_shape0);
           const auto box_shape1 = petsird_helpers::geometry::get_detecting_box(header.scanner, type_of_module, expanded_detection_bin1);

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -97,6 +97,8 @@
 #include "protocols.h"
 #include "types.h"
 #include "binary/protocols.h"
+#include "petsird_helpers/create.h"
+#include "petsird_helpers/geometry.h"
 
 using namespace std ;
 
@@ -270,32 +272,28 @@ void usage()
   std::cout << "  -h, --help                                  Print this help message" << std::endl;
 }
 
-int calculate_detector_id(int gantry_id, int rsector_id, int module_id, int submodule_id, int crystal_id, ScannerGeometry& scannerGeometry, int rmin = 0)
+int calculate_element_index(int module_id, int submodule_id, int crystal_id, const ScannerGeometry& scannerGeometry)
 {
-  // In code below replace N_RINGS with scannerGeometry.n_rings, etc.
-  int N_DET = scannerGeometry.n_det;
-  int N_RSEC_xy = scannerGeometry.n_rsec_xy;
-  int N_RSEC_z = scannerGeometry.n_rsec_z;
-  int N_MOD_xy = scannerGeometry.n_mod_xy;
-  int N_MOD_z = scannerGeometry.n_mod_z;
+  //int N_DET = scannerGeometry.n_det;
+  //int N_MOD_xy = scannerGeometry.n_mod_xy;
+  //int N_MOD_z = scannerGeometry.n_mod_z;
   int N_SMOD_xy = scannerGeometry.n_smod_xy;
   int N_SMOD_z = scannerGeometry.n_smod_z;
   int N_CRY_xy = scannerGeometry.n_cry_xy;
   int N_CRY_z = scannerGeometry.n_cry_z;
   // int N_CRY_layers = scannerGeometry.n_cry_layers;
 
-  int ring = (Int_t)(gantry_id)*N_RSEC_z*N_MOD_z*N_SMOD_z*N_CRY_z
-           + (Int_t)(rsector_id/N_RSEC_xy)*N_MOD_z*N_SMOD_z*N_CRY_z
-           + (Int_t)(module_id/N_MOD_xy)*N_SMOD_z*N_CRY_z
-           + (Int_t)(submodule_id/N_SMOD_xy)*N_CRY_z
-           + (Int_t)(crystal_id/N_CRY_xy);
+  return (Int_t)((module_id*N_SMOD_xy*N_SMOD_z)
+                 + submodule_id*N_CRY_xy*N_CRY_z
+                 + crystal_id);
+}
 
-  int crystal = (Int_t)(crystal_id%N_CRY_xy)
-              + (Int_t)(submodule_id%N_SMOD_xy)*N_CRY_xy
-              + (Int_t)(module_id%N_MOD_xy)*N_SMOD_xy*N_CRY_xy
-              + (Int_t)(rsector_id%N_RSEC_xy)*N_MOD_xy*N_SMOD_xy*N_CRY_xy;
+int calculate_module_index(int gantry_id, int rsector_id, const ScannerGeometry& scannerGeometry)
+{
+  const int N_RSEC_xy = scannerGeometry.n_rsec_xy;
+  const int N_RSEC_z = scannerGeometry.n_rsec_z;
 
-  return crystal + (ring-rmin)*N_DET;
+  return (Int_t)(gantry_id)*N_RSEC_z*N_RSEC_xy + (Int_t)rsector_id;
 }
 
 //! return a cuboid volume
@@ -323,7 +321,6 @@ get_detector_module(ScannerGeometry& scannerGeometry)
   petsird::ReplicatedBoxSolidVolume rep_volume;
   {
     rep_volume.object = get_crystal(scannerGeometry);
-    int crystal_id = 0;
     for (int rep_mod_xy = 0; rep_mod_xy < scannerGeometry.n_mod_xy; ++rep_mod_xy)
         for (int rep_mod_z = 0; rep_mod_z < scannerGeometry.n_mod_z; ++rep_mod_z)
           for (int rep_smod_xy = 0; rep_smod_xy < scannerGeometry.n_smod_xy; ++rep_smod_xy)
@@ -340,15 +337,11 @@ get_detector_module(ScannerGeometry& scannerGeometry)
                                                                                + (rep_smod_z - scannerGeometry.n_smod_z / 2) * scannerGeometry.n_cry_z * scannerGeometry.detector_z_dim
                                                                                + (rep_cry_z - scannerGeometry.n_cry_z / 2) * scannerGeometry.detector_z_dim } } };
                       rep_volume.transforms.push_back(transform);
-                      //rep_volume.ids.push_back(rep_cry_layer + n_cry_layer * (rep_cry_xy + n_cry_xy * rep_cry_z));
-                      //rep_volume.ids.push_back(rep_cry_z + scannerGeometry.n_cry_z * (rep_cry_xy + scannerGeometry.n_cry_xy * rep_cry_layer));
-                      rep_volume.ids.push_back(crystal_id++);
                     }
   }
 
   petsird::DetectorModule detector_module;
-  detector_module.detecting_elements.push_back(rep_volume);
-  detector_module.detecting_element_ids.push_back(0);
+  detector_module.detecting_elements = rep_volume;
 
   return detector_module;
 }
@@ -361,7 +354,6 @@ get_scanner_geometry(ScannerGeometry& scannerGeometry)
   petsird::ReplicatedDetectorModule rep_module;
   {
     rep_module.object = get_detector_module(scannerGeometry);
-    int module_id = 0;
     std::vector<float> angles;
     for (int i = 0; i < scannerGeometry.n_rsec_xy; ++i)
       {
@@ -375,13 +367,11 @@ get_scanner_geometry(ScannerGeometry& scannerGeometry)
                                                     { -std::sin(angle), std::cos(angle), 0.F, 0.F},
                                                     { 0.F, 0.F, 1.F, (rep_rsec_z - scannerGeometry.n_rsec_z / 2) * scannerGeometry.n_mod_z * scannerGeometry.n_smod_z * scannerGeometry.n_cry_z * scannerGeometry.detector_z_dim} } };
 
-          rep_module.ids.push_back(module_id++);
           rep_module.transforms.push_back(transform);
         }
   }
   petsird::ScannerGeometry scanner_geometry;
   scanner_geometry.replicated_modules.push_back(rep_module);
-  scanner_geometry.ids.push_back(0);
   return scanner_geometry;
 }
 
@@ -393,30 +383,57 @@ get_scanner_info(ScannerGeometry& scannerGeometry)
   // int n_detectors = scannerGeometry.n_det;
   // int n_rings = scannerGeometry.n_rings;
   unsigned long NUMBER_OF_TOF_BINS = static_cast<unsigned long>(scannerGeometry.number_of_tof_bins);
-  unsigned long NUMBER_OF_ENERGY_BINS = static_cast<unsigned long>(scannerGeometry.number_of_energy_bins);
+  unsigned long NUMBER_OF_EVENT_ENERGY_BINS = static_cast<unsigned long>(scannerGeometry.number_of_energy_bins);
   float energy_LLD = scannerGeometry.energy_LLD;
   float energy_ULD =scannerGeometry.energy_ULD;
 
-  typedef yardl::NDArray<float, 1> FArray1D;
-  // TOF info (in mm)
-  FArray1D::shape_type tof_bin_edges_shape = { NUMBER_OF_TOF_BINS + 1 };
-  FArray1D tof_bin_edges(tof_bin_edges_shape);
-  for (std::size_t i = 0; i < tof_bin_edges.size(); ++i) {
-    tof_bin_edges[i] = (i - NUMBER_OF_TOF_BINS / 2.F) / NUMBER_OF_TOF_BINS * scannerGeometry.TxFOV_TOF;
-  }
-  FArray1D::shape_type energy_bin_edges_shape = { NUMBER_OF_ENERGY_BINS + 1 };
-  FArray1D energy_bin_edges(energy_bin_edges_shape);
-  for (std::size_t i = 0; i < energy_bin_edges.size(); ++i) {
-    energy_bin_edges[i] = energy_LLD + i * (energy_ULD - energy_LLD) / NUMBER_OF_ENERGY_BINS;
-  }
   petsird::ScannerInformation scanner_info;
-  scanner_info.scanner_geometry = get_scanner_geometry(scannerGeometry);
-  // scanner_info.detectors = detectors;
-  scanner_info.tof_bin_edges = tof_bin_edges;
-  scanner_info.tof_resolution = scannerGeometry.TOF_resolution*0.3; // conversion from psec to mm (e.g. 200ps TOF is equivalent to 60mm uncertainty)
-  scanner_info.energy_bin_edges = energy_bin_edges;
-  scanner_info.energy_resolution_at_511 = scannerGeometry.EnergyResolutionAt511;    // as fraction of 511 (e.g. 0.11F)
-  scanner_info.event_time_block_duration = scannerGeometry.LM_TimeBlockDuration; // ms
+  scanner_info.model_name = "PETSIRD_GATEROOT"; // TODO
+
+  const auto num_types_of_modules = 1;
+  // Pre-allocate various structures to have the correct size for num_types_of_modules
+  // (We will still have to set descent values into each of these.)
+  petsird_helpers::create::initialize_scanner_information_dimensions(scanner_info, num_types_of_modules,
+                                                                     /* allocate_detection_bin_efficiencies = */ false,
+                                                                     /* allocate_module_pair_efficiencies = */ false);
+
+  // TODO scanner_info.bulk_materials
+
+  // TOF and energy information
+  {
+    auto& all_tof_bin_edges = scanner_info.tof_bin_edges;
+    auto& all_tof_resolutions = scanner_info.tof_resolution;
+    auto& all_event_energy_bin_edges = scanner_info.event_energy_bin_edges;
+    auto& all_event_energy_resolutions = scanner_info.energy_resolution_at_511;
+
+    // only 1 type of module in the current scanner
+    assert(num_types_of_modules == 1);
+    const petsird::TypeOfModule type_of_module{ 0 };
+
+    typedef yardl::NDArray<float, 1> FArray1D;
+    // TOF info (in mm)
+    FArray1D tof_bin_edges_arr;
+    yardl::resize(tof_bin_edges_arr, { NUMBER_OF_TOF_BINS + 1 });
+    for (std::size_t i = 0; i < tof_bin_edges_arr.size(); ++i)
+      tof_bin_edges_arr[i] = (i - NUMBER_OF_TOF_BINS / 2.F) / NUMBER_OF_TOF_BINS * 2 * scannerGeometry.TxFOV_TOF;
+    const petsird::BinEdges tof_bin_edges{ tof_bin_edges_arr };
+    all_tof_bin_edges[type_of_module][type_of_module] = tof_bin_edges;
+
+    // TODO use speed-of-light here
+    all_tof_resolutions[type_of_module][type_of_module] = scannerGeometry.TOF_resolution*0.3; // conversion from psec to mm (e.g. 200ps TOF is equivalent to 60mm uncertainty)
+
+    FArray1D event_energy_bin_edges_arr;
+    yardl::resize(event_energy_bin_edges_arr, { NUMBER_OF_EVENT_ENERGY_BINS + 1 });
+    for (std::size_t i = 0; i < event_energy_bin_edges_arr.size(); ++i)
+      event_energy_bin_edges_arr[i] = energy_LLD + i * (energy_ULD - energy_LLD) / NUMBER_OF_EVENT_ENERGY_BINS;
+    petsird::BinEdges event_energy_bin_edges{ event_energy_bin_edges_arr };
+    all_event_energy_bin_edges[type_of_module] = event_energy_bin_edges;
+    all_event_energy_resolutions[type_of_module] = scannerGeometry.EnergyResolutionAt511;    // as fraction of 511 (e.g. 0.11F)
+  }
+
+  // TODO scanner_info.coincidence_policy = petsird::CoincidencePolicy::kRejectMultiples;
+  scanner_info.delayed_coincidences_are_stored = false;
+  scanner_info.triple_events_are_stored = false;
   return scanner_info;
 }
 
@@ -424,10 +441,13 @@ get_scanner_info(ScannerGeometry& scannerGeometry)
 
 uint32_t tofToIdx(double delta_time_psec, const petsird::ScannerInformation& scanner_info)
 {
+  constexpr petsird::TypeOfModule type_of_module{ 0 };
+  const auto& tof_bin_edges = scanner_info.tof_bin_edges[type_of_module][type_of_module].edges;
+
   float tofPos_mm = delta_time_psec * 0.15; //conversion from time difference (in psec) to spatial position in LOR (in mm) DT*C/2
-  for (size_t i = 0; i < scanner_info.tof_bin_edges.size() - 1; ++i)
+  for (size_t i = 0; i < tof_bin_edges.size() - 1; ++i)
   {
-    if (tofPos_mm >= scanner_info.tof_bin_edges[i] && tofPos_mm < scanner_info.tof_bin_edges[i+1])
+    if (tofPos_mm >= tof_bin_edges[i] && tofPos_mm < tof_bin_edges[i+1])
     {
       return static_cast<uint32_t>(i);
     }
@@ -440,9 +460,11 @@ uint32_t tofToIdx(double delta_time_psec, const petsird::ScannerInformation& sca
 
 uint32_t energyToIdx(float energy, const petsird::ScannerInformation& scanner_info)
 {
-  for (size_t i = 0; i < scanner_info.energy_bin_edges.size() - 1; ++i)
+  constexpr petsird::TypeOfModule type_of_module{ 0 };
+  const auto& energy_bin_edges = scanner_info.event_energy_bin_edges[type_of_module].edges;
+  for (size_t i = 0; i < energy_bin_edges.size() - 1; ++i)
   {
-    if (energy >= scanner_info.energy_bin_edges[i] && energy < scanner_info.energy_bin_edges[i+1])
+    if (energy >= energy_bin_edges[i] && energy < energy_bin_edges[i+1])
     {
       return static_cast<uint32_t>(i);
     }
@@ -450,6 +472,18 @@ uint32_t energyToIdx(float energy, const petsird::ScannerInformation& scanner_in
   std::stringstream ss;
   ss << "WARNING: Energy out of range: " << energy;
   throw std::runtime_error(ss.str());
+}
+
+petsird::Coordinate mean_position(const petsird::BoxShape& box_shape)
+{
+  petsird::Coordinate mean;
+  mean.c = {0, 0, 0};
+  for (auto& corner : box_shape.corners)
+    {
+      mean.c += corner.c;
+    }
+  mean.c /= box_shape.corners.size();
+  return mean;
 }
 
 int main(int argc, char** argv)
@@ -594,26 +628,22 @@ int main(int argc, char** argv)
 
   // Output PETSIRD
   petsird::Header header;
-  petsird::ScannerInformation scanner = get_scanner_info(scannerGeometry);
+  header.scanner = get_scanner_info(scannerGeometry);
+  auto& scanner = header.scanner;
 
   if (verbose) {
     // Print scanner information
     std::cout << "Scanner information:" << std::endl;
-    std::cout << "Number of TOF bins: " << scanner.NumberOfTOFBins() << std::endl;
-    std::cout << "Number of energy bins: " << scanner.NumberOfEnergyBins() << std::endl;
-    const auto& tof_bin_edges = scanner.tof_bin_edges;
-    std::cout << "TOF bin edges: " << tof_bin_edges << std::endl;
-    const auto& energy_bin_edges = scanner.energy_bin_edges;
-    std::cout << "Energy bin edges: " << energy_bin_edges << std::endl;
-    //for (auto d : scanner.detectors) {
-    //  std::cout << "    Detector " << d.id << ": (" << d.x << ", " << d.y << ", " << d.z << ")" << std::endl;
-    //}
+    constexpr petsird::TypeOfModule type_of_module{ 0 };
+    const auto& tof_bin_edges = header.scanner.tof_bin_edges[type_of_module][type_of_module];
+    const auto num_tof_bins = tof_bin_edges.NumberOfBins();
+    std::cout << "Number of TOF bins: " << num_tof_bins << std::endl;
+    std::cout << "TOF bin edges: " << tof_bin_edges.edges << std::endl;
+    const auto& event_energy_bin_edges = header.scanner.event_energy_bin_edges[type_of_module];
+    const auto num_event_energy_bins = event_energy_bin_edges.NumberOfBins();
+    std::cout << "Number of energy bins: " << num_event_energy_bins << std::endl;
+    std::cout << "Event energy bin edges: " << event_energy_bin_edges.edges << std::endl;
   }
-
-  petsird::ExamInformation exam;
-
-  header.exam = exam;
-  header.scanner = scanner;
 
   // Write PETSiRD file
   petsird::binary::PETSIRDWriter writer(petsird_file);
@@ -621,6 +651,8 @@ int main(int argc, char** argv)
 
   long current_time_block = -1;
   petsird::EventTimeBlock time_block;
+  const auto event_time_block_duration = scannerGeometry.LM_TimeBlockDuration; // ms
+  const petsird::TypeOfModule type_of_module{ 0 };
   unsigned long Counts_binned = 0;
   for (unsigned long long int i = 0 ; i < nentries ; i++)
   {
@@ -633,42 +665,60 @@ int main(int argc, char** argv)
     {
 	    if (comptonPhantom1 == 0 && comptonPhantom2 == 0) {
         petsird::CoincidenceEvent event;
-        event.detector_ids[0] = calculate_detector_id(gantryID1, rsectorID1, moduleID1, submoduleID1, crystalID1, scannerGeometry);
-        event.detector_ids[1] = calculate_detector_id(gantryID2, rsectorID2, moduleID2, submoduleID2, crystalID2, scannerGeometry);
+        petsird::ExpandedDetectionBin expanded_detection_bin;
+        expanded_detection_bin.module_index = calculate_module_index(gantryID1, rsectorID1, scannerGeometry);
+        expanded_detection_bin.element_index = calculate_element_index(moduleID1, submoduleID1, crystalID1, scannerGeometry);
+        expanded_detection_bin.energy_index = static_cast<uint32_t>(energyToIdx(1.0e3*energy1, scanner));
+        event.detection_bins[0] = petsird_helpers::make_detection_bin(header.scanner, type_of_module, expanded_detection_bin);
+        expanded_detection_bin.module_index = calculate_module_index(gantryID2, rsectorID2, scannerGeometry);
+        expanded_detection_bin.element_index = calculate_element_index(moduleID1, submoduleID1, crystalID1, scannerGeometry);
+        expanded_detection_bin.energy_index = static_cast<uint32_t>(energyToIdx(1.0e3*energy2, scanner));
+        event.detection_bins[1] = petsird_helpers::make_detection_bin(header.scanner, type_of_module, expanded_detection_bin);
         double dt_psec = 1.0e12f*(time1 - time2); //in psec
         if (abs(dt_psec) > scannerGeometry.TxFOV_TOF/0.3f) {
           continue;
         }
         event.tof_idx = static_cast<uint32_t>(tofToIdx(dt_psec, scanner));
-        event.energy_indices[0] = static_cast<uint32_t>(energyToIdx(1.0e3*energy1, scanner));
-        event.energy_indices[1] = static_cast<uint32_t>(energyToIdx(1.0e3*energy2, scanner));
 
         if (verbose && i%100000 == 0) {
           std::cout << "Event " << i << std::endl;
-          std::cout << "  detector_1_id: " << event.detector_ids[0] << std::endl;
-          std::cout << "  detector_2_id: " << event.detector_ids[1] << std::endl;
+          const auto expanded_detection_bin0
+            = petsird_helpers::expand_detection_bin(header.scanner, type_of_module, event.detection_bins[0]);
+          const auto expanded_detection_bin1
+            = petsird_helpers::expand_detection_bin(header.scanner, type_of_module, event.detection_bins[1]);
+          std::cout << "    "
+                    << "[ExpandedDetectionBin(module=" << expanded_detection_bin0.module_index << ", "
+                    << "el=" << expanded_detection_bin0.element_index << ", "
+                    << "energy_index=" << expanded_detection_bin0.energy_index
+                    << "), ExpandedDetectionBin(module=" << expanded_detection_bin1.module_index << ", "
+                    << "el=" << expanded_detection_bin1.element_index << ", "
+                    << "energy_index=" << expanded_detection_bin1.energy_index << ")]\n";
           std::cout << "  tof_idx: " << event.tof_idx << std::endl;
-          std::cout << "  energy_1_idx: " << event.energy_indices[0] << std::endl;
-          std::cout << "  energy_2_idx: " << event.energy_indices[1] << std::endl;
-          //std::cout << "  detector 1 position: " << scanner.detectors[event.detector_ids[0]].x << ", " << scanner.detectors[event.detector_ids[0]].y << ", " << scanner.detectors[event.detector_ids[0]].z << std::endl;
-          //std::cout << "  GlobalPosition 1: " << globalPosX1 << ", " << globalPosY1 << ", " << globalPosZ1 << std::endl;
+          const auto box_shape0 = petsird_helpers::geometry::get_detecting_box(header.scanner, type_of_module, expanded_detection_bin0);
+          const auto mean_pos0 = mean_position(box_shape0);
+          const auto box_shape1 = petsird_helpers::geometry::get_detecting_box(header.scanner, type_of_module, expanded_detection_bin1);
+          const auto mean_pos1 = mean_position(box_shape1);
+          std::cout << "  pos 1          : " << mean_pos0.c[0] << ", " << mean_pos0.c[1] << ", " << mean_pos0.c[2] << "\n";
+          std::cout << "  pos 2          : " << mean_pos1.c[0] << ", " << mean_pos1.c[1] << ", " << mean_pos1.c[2] << "\n";
+
+          std::cout << "  GlobalPosition 1: " << globalPosX1 << ", " << globalPosY1 << ", " << globalPosZ1 << std::endl;
           //float distance_1 = std::sqrt(std::pow(scanner.detectors[event.detector_ids[0]].x-globalPosX1, 2) + std::pow(scanner.detectors[event.detector_ids[0]].y-globalPosY1, 2) + std::pow(scanner.detectors[event.detector_ids[0]].z-globalPosZ1, 2));
           //std::cout << "  Distance 1: " << distance_1 << std::endl;
-          //std::cout << "  detector 2 position: " << scanner.detectors[event.detector_ids[1]].x << ", " << scanner.detectors[event.detector_ids[1]].y << ", " << scanner.detectors[event.detector_ids[1]].z << std::endl;
-          //std::cout << "  GlobalPosition 2: " << globalPosX2 << ", " << globalPosY2 << ", " << globalPosZ2 << std::endl;
+          std::cout << "  GlobalPosition 2: " << globalPosX2 << ", " << globalPosY2 << ", " << globalPosZ2 << std::endl;
           //float distance_2 = std::sqrt(std::pow(scanner.detectors[event.detector_ids[1]].x-globalPosX2, 2) + std::pow(scanner.detectors[event.detector_ids[1]].y-globalPosY2, 2) + std::pow(scanner.detectors[event.detector_ids[1]].z-globalPosZ2, 2));
           //std::cout << "  Distance 2: " << distance_2 << std::endl;
         }
-        long this_time_block = static_cast<long>(time1*1.0e3 / scanner.event_time_block_duration);
+        long this_time_block = static_cast<long>(time1*1.0e3 / event_time_block_duration);
         if (this_time_block != current_time_block) {
           if (current_time_block != -1) {
             writer.WriteTimeBlocks(time_block);
           }
           current_time_block = this_time_block;
           time_block = petsird::EventTimeBlock{};
-          time_block.start = time1*1.0e3;
+          time_block.time_interval.start = time1*1.0e3;
+          time_block.time_interval.stop = time1*1.0e3 + event_time_block_duration;
         }
-        time_block.prompt_events.push_back(event);
+        time_block.prompt_events[type_of_module][type_of_module].push_back(event);
         Counts_binned++;
         Trues++;
       } else {

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -67,31 +67,11 @@
 #include <fstream>
 #include <string>
 #include <vector>
-#include <math.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include "TROOT.h"
-#include "TSystem.h"
 #include "TChain.h"
-#include "TH2D.h"
-#include "TDirectory.h"
-#include "TList.h"
-#include "Rtypes.h"
-#include "TChainElement.h"
-#include "TTree.h"
-#include "TFile.h"
-#include "TStyle.h"
-#include "TH2.h"
-#include "TH2F.h"
-#include "TCanvas.h"
-#include "TRandom.h"
-#include <time.h>
 #include <cmath>
 
 #include <nlohmann/json.hpp>
-
-#include <xtensor/xview.hpp>
-#include <xtensor/xio.hpp>
 
 // PETSIRD Includes
 #include "protocols.h"

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -700,11 +700,11 @@ int main(int argc, char** argv)
           std::cout << "  pos 2          : " << mean_pos1.c[0] << ", " << mean_pos1.c[1] << ", " << mean_pos1.c[2] << "\n";
 
           std::cout << "  GlobalPosition 1: " << globalPosX1 << ", " << globalPosY1 << ", " << globalPosZ1 << std::endl;
-          //float distance_1 = std::sqrt(std::pow(scanner.detectors[event.detector_ids[0]].x-globalPosX1, 2) + std::pow(scanner.detectors[event.detector_ids[0]].y-globalPosY1, 2) + std::pow(scanner.detectors[event.detector_ids[0]].z-globalPosZ1, 2));
-          //std::cout << "  Distance 1: " << distance_1 << std::endl;
+          float distance_1 = std::sqrt(std::pow(mean_pos0.c[0]-globalPosX1, 2) + std::pow(mean_pos0.c[1]+globalPosY1, 2) + std::pow(mean_pos0.c[2]-globalPosZ1, 2));
+          std::cout << "  Distance 1: " << distance_1 << std::endl;
           std::cout << "  GlobalPosition 2: " << globalPosX2 << ", " << globalPosY2 << ", " << globalPosZ2 << std::endl;
-          //float distance_2 = std::sqrt(std::pow(scanner.detectors[event.detector_ids[1]].x-globalPosX2, 2) + std::pow(scanner.detectors[event.detector_ids[1]].y-globalPosY2, 2) + std::pow(scanner.detectors[event.detector_ids[1]].z-globalPosZ2, 2));
-          //std::cout << "  Distance 2: " << distance_2 << std::endl;
+          float distance_2 = std::sqrt(std::pow(mean_pos1.c[0]-globalPosX2, 2) + std::pow(mean_pos1.c[1]+globalPosY2, 2) + std::pow(mean_pos1.c[2]-globalPosZ2, 2));
+          std::cout << "  Distance 2: " << distance_2 << std::endl;
         }
         long this_time_block = static_cast<long>(time1*1.0e3 / event_time_block_duration);
         if (this_time_block != current_time_block) {

--- a/environment.yml
+++ b/environment.yml
@@ -1,24 +1,20 @@
-name: petsird
+name: GATEROOT
 channels:
   - conda-forge
   - defaults
 dependencies:
   - bash-completion>=2.11
   - cmake>=3.21.3
-  - compilers
+  - cxx-compiler
   - dvc-azure=2.23.0
   - fmt>=8.1.1
   - gh=2.38.0
-  - h5py>=3.7.0
   - hdf5>=1.12.1
   - howardhinnant_date>=3.0.1
-  - ipykernel>=6.19.2
-  - just=1.16.0
+  - just=1.36.0
   - ninja>=1.11.0
   - nlohmann_json>=3.11.2
-  - numpy>=1.24.3
-  - python=3.9
-  - root=6.28
+  - root_base>=6.28
   - shellcheck>=0.8.0
-  - xtensor-fftw>=0.2.5
-  - xtensor>=0.24.2
+  - xtensor>=0.24.2, <0.26.0
+  - xtensor-blas


### PR DESCRIPTION
## Changes in this pull request

This compiles with PETSIRD v0.7.2. Note that the PETSIRD submodule has been updated accordingly, so you will need to
- use yardl 0.6.3

- update the code as follows
  ```sh
  git fetch origin
  git checkout updatePETSIRD0.7
  git submodule update --init
  ```
- update your dependencies (mostly xtensor-blas), easiest via
  ```sh
   conda env create -f environment.yml
   conda activate GATEROOT
   ```
- remove existing build (as it might point to wrong environment) and build from scratch
  ```sh
   rm -rf cpp/build
   just build
   ```

**WARNING**: I am not sure if the current code is correct, as I don't know how GATE orders "crystals" in modules/submodules/crystal IDs. This is important, as I no longer go via `ring`, `det` coordinates (which were used in the previous version).

@nkarakatsanis @sstute1 Please check this!

## Testing performed
I haven't tested this myself, as I don't have the scanner geometry for my ROOT file. Possibly it might be easy to make...

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
