### PR TITLE
Add functionality to set detection efficiencies and minor updates to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,4 +45,44 @@ default: run
 @run_6min_voxBrain: build
     cpp/build/root_to_petsird --root-prefix ROOT_DATA/voxBrain/ETSIPETscanner256mmAFOV_positronSource/ETSIPETscanner256mmAFOV_voxBrain_ --number-of-root-files 36 --petsird-file petsird_ETSIPETscanner256mmAFOV_voxBrain_6min_v0.2.bin -s data/root/ETSIPETscanner256mmAFOV_geometry.json
 
-@run: run_0min_voxBrain
+@run_ONLY_0min_mIEC:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/IEC/ETSIPETscanner_mIEC_ --number-of-root-files 0 --petsird-file petsird_ETSIPETscanner_Norm_mIEC_0min_v0.7.2.bin -s data/root/ETSIPETscanner_geometry.json
+
+@run_ONLY_10sec_mIEC:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/IEC/ETSIPETscanner_mIEC_ --number-of-root-files 1 --petsird-file petsird_ETSIPETscanner_Norm_mIEC_10sec_v0.7.2.bin -s data/root/ETSIPETscanner_geometry.json
+
+@run_ONLY_6min_mIEC:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/IEC/ETSIPETscanner_mIEC_ --number-of-root-files 36 --petsird-file petsird_ETSIPETscanner_Norm_mIEC_6min_v0.7.2.bin -s data/root/ETSIPETscanner_geometry.json
+
+
+
+@run_ONLY_0min_voxBrain:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/voxBrain/ETSIPETscanner256mmAFOV_positronSource/ETSIPETscanner256mmAFOV_voxBrain_ --number-of-root-files 0 --petsird-file petsird_ETSIPETscanner256mmAFOV_Norm_voxBrain_0min_v0.7.2.bin -s data/root/ETS$
+
+@run_ONLY_3min_voxBrain:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/voxBrain/ETSIPETscanner256mmAFOV_positronSource/ETSIPETscanner256mmAFOV_voxBrain_ --number-of-root-files 18 --petsird-file petsird_ETSIPETscanner256mmAFOV_Norm_voxBrain_3min_v0.7.2.bin -s data/root/ET$
+
+@run_ONLY_6min_voxBrain:
+    cpp/build/root_to_petsird --root-prefix ../ROOT_files/voxBrain/ETSIPETscanner256mmAFOV_positronSource/ETSIPETscanner256mmAFOV_voxBrain_ --number-of-root-files 36 --petsird-file petsird_ETSIPETscanner256mmAFOV_Norm_voxBrain_6min_v0.7.2.bin -s data/root/ET$
+
+
+
+#Run only (built assumed validated)
+#@run: run_ONLY_0min_mIEC
+#@run: run_ONLY_10sec_mIEC
+@run: run_ONLY_6min_mIEC
+
+#@run: run_ONLY_0min_voxBrain
+#@run: run_ONLY_3min_voxBrain
+#@run: run_ONLY_6min_voxBrain
+
+
+
+# Build and run
+#@run: run_0min_mIEC
+#@run: run_10sec_mIEC
+#@run: run_6min_mIEC
+
+#@run: run_0min_voxBrain
+#@run: run_3min_voxBrain
+#@run: run_6min_voxBrain


### PR DESCRIPTION
## Changes in this pull request
Add functionality to set detection efficiencies and minor updates to justfile

## Testing performed
PETSIRD data with set detection efficiencies of 1 produced. We assume only rotational symmetries at the moment. Axial symmetries and block symmetries to be included in future versions.

Observation: The size of the output PETSIRD files has increased considerably due to the inclusion of the normalization factors in the header.


## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
